### PR TITLE
clone model before merge to keep builtModels unmutated and true to swagger def

### DIFF
--- a/lib/swamp.js
+++ b/lib/swamp.js
@@ -77,7 +77,7 @@ class SwampRegistry {
         if (restrict) {
             return lodash.pick(defaults, lodash.keys(this.builtModels[modelName]));
         } else {
-            return lodash.merge(this.builtModels[modelName], defaults);
+            return lodash.merge(lodash.clone(this.builtModels[modelName]), defaults);
         }
     }
 


### PR DESCRIPTION
This little change allows us to do something cool. We can call get() a first time without a third arg which keeps strict set to false and merges objects. This means we'll have both null items from the swagger def that aren't in the db, and db fields not in the swagger def.

Then we can call get() a second time with true for the third arg. This will restrict the output to the swagger def (now that we have this commit). Super useful combo. 
